### PR TITLE
don't use arguments

### DIFF
--- a/src/autobind.js
+++ b/src/autobind.js
@@ -103,8 +103,8 @@ function handle(args) {
 
 export default function autobind(...args) {
   if (args.length === 0) {
-    return function () {
-      return handle(args);
+    return function (...argsClass) {
+      return handle(argsClass);
     };
   } else {
     return handle(args);

--- a/src/autobind.js
+++ b/src/autobind.js
@@ -104,7 +104,7 @@ function handle(args) {
 export default function autobind(...args) {
   if (args.length === 0) {
     return function () {
-      return handle(arguments);
+      return handle(args);
     };
   } else {
     return handle(args);


### PR DESCRIPTION
Accessing `arguments` inside a function is slow so.
Now used `args` instead of `arguments`